### PR TITLE
Feature/configurable drupal build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Isn't fancy or interesting or even really a proper project.  It's just a Vagrant
 6. CD into the root directory of the project and run ``vagrant up``.  Be patient - installation takes time. 
 7. Type ``vagrant ssh`` and you should be ssh'd directly into the machine.  Since none of the components talk to each other (yet) this is everything you need to do.  Do note that the Rails server isn't actually running, and that if you need it for anything you'll need to go start it.  The tapas project should be accessible from your machine's browser at localhost:8080.
 
+## Startup options
+
+Passing environmental variables to the `vagrant up` command allows for configuration of the final build.  To do this, prepend the desired environmental variable to the command like so: `SOME_ENV=value vagrant up`.  
+
+Currently, there is only one supported option: 
+* BUILDTAPAS_BRANCH: Passing this to the script will alter which branch of the [buildtapas](https://github.com/neu-dsg/buildtapas) project is used to construct the site.  This currently defaults to the develop branch and can be set in your custom configuration options with the key 'buildtapas_branch.'  
+
 Then see http://github.com/NEU-DSG/tapas/wiki/Running-tapas,-tapas-rails,-and-eXist-in-the-development-environment
 
 ## Hungry for more TAPAS?

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   custom_config["tapas_rails_directory"] ||= "~/tapas_rails"
   custom_config["drupal_share_directory"] ||= "~/tapas-drupal"
 
+  # Set the branch of buildtapas (github.com/neu-dsg/buildtapas) to use when building
+  # the site.  Check command line arguments first, then the custom_config hash, then 
+  # default to develop.
+  tapas_branch = ENV['BUILDTAPAS_BRANCH'] || 
+    custom_config['buildtapas_branch'] || 
+    'develop'
+
+
   # Caches yum packages to cut down on install time after the first 
   # build.  Note that cached packages will be reused for any other 
   # chef/centos-6.5 boxes.
@@ -73,7 +81,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell" do |s| 
     s.path = "scripts/plattr_provisioning.sh"
     s.privileged = false
-    s.args = ["#{ENV['USER_ID']}"]
+    s.args = ["\"#{ENV['USER_ID']}\" \"#{tapas_branch}\""]
   end
 
   config.vm.synced_folder custom_config["tapas_rails_directory"], "/home/vagrant/tapas_rails", nfs: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,7 +81,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell" do |s| 
     s.path = "scripts/plattr_provisioning.sh"
     s.privileged = false
-    s.args = ["\"#{ENV['USER_ID']}\" \"#{tapas_branch}\""]
+    s.args = ["#{ENV['USER_ID']}", "#{tapas_branch}"]
   end
 
   config.vm.synced_folder custom_config["tapas_rails_directory"], "/home/vagrant/tapas_rails", nfs: true

--- a/scripts/plattr_provisioning.sh
+++ b/scripts/plattr_provisioning.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash 
 /bin/bash --login
 
+# Before doing anything else, verify that the specified buildtapas branch 
+# exists on github and is accessible.
+branch=$2
+buildtapas_repo="https://github.com/neu-dsg/buildtapas.git"
+all_repos=$(git ls-remote -h $buildtapas_repo $branch)
+
+# This check ensures that we are getting an exact match on our branch
+if [[ $all_repos != *"refs/heads/$branch"* ]]; then
+  echo "There is no buildtapas branch on github named $branch" >&2
+  exit 1
+fi
+
 # Update composer
 /usr/local/bin/composer self-update
 # Update drush
@@ -69,7 +81,7 @@ sudo chown -R vagrant /var/www/html
 echo "export PATH=\$PATH:/home/vagrant/.composer/vendor/bin" >> /home/vagrant/.bashrc
 # buildtapas script places the site in the directory it is executed from
 cd /var/www/html
-curl -O https://raw.githubusercontent.com/neu-dsg/buildtapas/develop/buildtapas.sh
+curl -O https://raw.githubusercontent.com/neu-dsg/buildtapas/$branch/buildtapas.sh
 sed -i.bak 's/8080/3306/g' buildtapas.sh
 /bin/bash --login /var/www/html/buildtapas.sh "root" "" "tapas_drupal" "drupaldb" "drupaldb"
 


### PR DESCRIPTION
You may now pass BUILDTAPAS_BRANCH as an environmental variable during vagrant up or vagrant provision and the specified branch will be used to build the Drupal site.
